### PR TITLE
initial PR for docs

### DIFF
--- a/documents/Makefile
+++ b/documents/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = .
+BUILDDIR      = _build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/documents/conf.py
+++ b/documents/conf.py
@@ -1,0 +1,61 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# This file only contains a selection of the most common options. For a full
+# list see the documentation:
+# http://www.sphinx-doc.org/en/master/config
+
+# -- Path setup --------------------------------------------------------------
+
+# If extensions (or modules to document with autodoc) are in another directory,
+# add these directories to sys.path here. If the directory is relative to the
+# documentation root, use os.path.abspath to make it absolute, like shown here.
+#
+import sphinx_rtd_theme
+import os
+import sys
+sys.path.insert(0, os.path.abspath('~/exojax'))
+
+
+# -- Project information -----------------------------------------------------
+
+project = 'ExoJAX'
+copyright = '2020-2024, ExoJAX contributors'
+author = 'ExoJAX contributors'
+
+# The full version, including alpha/beta/rc tags
+release = '1.5.0'
+
+
+# -- General configuration ---------------------------------------------------
+
+# Add any Sphinx extension module names here, as strings. They can be
+# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
+# ones.
+extensions = ['sphinx.ext.autodoc', 'sphinx.ext.napoleon', 'sphinxemoji.sphinxemoji',
+              ]
+
+# Add any paths that contain templates here, relative to this directory.
+templates_path = ['_templates']
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+# This pattern also affects html_static_path and html_extra_path.
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+
+
+# -- Options for HTML output -------------------------------------------------
+
+# The theme to use for HTML and HTML Help pages.  See the documentation for
+# a list of builtin themes.
+#
+html_theme = 'sphinx_rtd_theme'
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+html_static_path = ['_static']
+html_logo = '_static/logo.png'
+
+#html_theme_options = {
+#    'style_nav_header_background': '#333',
+#}
+html_css_files = ['header.css']

--- a/documents/conf.py
+++ b/documents/conf.py
@@ -13,17 +13,17 @@
 import sphinx_rtd_theme
 import os
 import sys
-sys.path.insert(0, os.path.abspath('~/exojax'))
+sys.path.insert(0, os.path.abspath('~/jkepler'))
 
 
 # -- Project information -----------------------------------------------------
 
-project = 'ExoJAX'
-copyright = '2020-2024, ExoJAX contributors'
-author = 'ExoJAX contributors'
+project = 'jkepler'
+copyright = 'jkepler'
+author = 'Kento Masuda'
 
 # The full version, including alpha/beta/rc tags
-release = '1.5.0'
+release = '0.0.0'
 
 
 # -- General configuration ---------------------------------------------------

--- a/documents/index.rst
+++ b/documents/index.rst
@@ -1,4 +1,4 @@
-.. exojax documentation master file, created by
+.. jkepler documentation master file, created by
    sphinx-quickstart on Mon Jan 11 14:38:51 2021.
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.

--- a/documents/index.rst
+++ b/documents/index.rst
@@ -1,0 +1,17 @@
+.. exojax documentation master file, created by
+   sphinx-quickstart on Mon Jan 11 14:38:51 2021.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+   
+jkepler
+==================================
+
+
+   
+.. toctree::
+   :maxdepth: 1
+   :caption: API:
+
+   jkepler/jkepler.rst
+
+


### PR DESCRIPTION
addresses #4 

to compile the sphinx doc, at `jkepler` 
```sh
python setup.py install
rm -rf documents/jkepler
sphinx-apidoc -F -o documents/jkepler src/jkepler
cd documents
make clean
make html
```

See `documents/_build/html/`
The sample is 
https://secondearths.sakura.ne.jp/jkepler/

If you prefer Readthedoc to the local server, make the account.